### PR TITLE
Rate limited resource handlers

### DIFF
--- a/modules/client/account/3pid.cc
+++ b/modules/client/account/3pid.cc
@@ -64,6 +64,7 @@ post_3pid
 {
 	account_3pid, "POST", post__3pid,
 	{
-		post_3pid.REQUIRES_AUTH
+		post_3pid.REQUIRES_AUTH |
+		post_3pid.RATE_LIMITED // revisit this? some of these require rate limiting, some don't
 	}
 };

--- a/modules/client/account/deactivate.cc
+++ b/modules/client/account/deactivate.cc
@@ -61,6 +61,7 @@ post_deactivate
 {
 	account_deactivate, "POST", post__deactivate,
 	{
-		post_deactivate.REQUIRES_AUTH
+		post_deactivate.REQUIRES_AUTH |
+		post_deactivate.RATE_LIMITED
 	}
 };

--- a/modules/client/account/password.cc
+++ b/modules/client/account/password.cc
@@ -76,6 +76,7 @@ post_password
 {
 	account_password, "POST", post__password,
 	{
-		post_password.REQUIRES_AUTH
+		post_password.REQUIRES_AUTH |
+		post_password.RATE_LIMITED
 	}
 };

--- a/modules/client/account/whoami.cc
+++ b/modules/client/account/whoami.cc
@@ -39,6 +39,7 @@ get_whoami
 {
 	account_whoami, "GET", get__whoami,
 	{
-		get_whoami.REQUIRES_AUTH
+		get_whoami.REQUIRES_AUTH |
+		get_whoami.RATE_LIMITED
 	}
 };

--- a/modules/client/join.cc
+++ b/modules/client/join.cc
@@ -92,7 +92,8 @@ method_post
 {
 	join_resource, "POST", post__join,
 	{
-		method_post.REQUIRES_AUTH
+		method_post.REQUIRES_AUTH |
+		method_post.RATE_LIMITED
 	}
 };
 

--- a/modules/client/login.cc
+++ b/modules/client/login.cc
@@ -204,7 +204,10 @@ post__login(client &client,
 resource::method
 method_post
 {
-	login_resource, "POST", post__login
+	login_resource, "POST", post__login,
+	{
+		method_post.RATE_LIMITED
+	}
 };
 
 resource::response
@@ -233,5 +236,8 @@ get__login(client &client,
 resource::method
 method_get
 {
-	login_resource, "GET", get__login
+	login_resource, "GET", get__login,
+	{
+		method_get.RATE_LIMITED
+	}
 };

--- a/modules/client/presence.cc
+++ b/modules/client/presence.cc
@@ -153,7 +153,8 @@ method_put
 {
 	presence_resource, "PUT", put__presence,
 	{
-		method_put.REQUIRES_AUTH
+		method_put.REQUIRES_AUTH |
+		method_put.RATE_LIMITED
 	}
 };
 

--- a/modules/client/profile.cc
+++ b/modules/client/profile.cc
@@ -48,7 +48,8 @@ method_put
 {
 	profile_resource, "PUT", put__profile,
 	{
-		method_put.REQUIRES_AUTH
+		method_put.REQUIRES_AUTH |
+		method_put.RATE_LIMITED
 	}
 };
 

--- a/modules/client/pushers.cc
+++ b/modules/client/pushers.cc
@@ -43,7 +43,8 @@ ircd::m::push::pushers_set_post
 {
 	pushers_set_resource, "POST", handle_pushers_set,
 	{
-		pushers_set_post.REQUIRES_AUTH
+		pushers_set_post.REQUIRES_AUTH |
+		pushers_set_post.RATE_LIMITED              
 	}
 };
 

--- a/modules/client/pushrules.cc
+++ b/modules/client/pushrules.cc
@@ -226,8 +226,7 @@ ircd::m::push::method_put
 {
 	resource, "PUT", handle_put,
 	{
-		method_put.REQUIRES_AUTH |
-		method_put.RATE_LIMITED // review this!
+		method_put.REQUIRES_AUTH
 	}
 };
 

--- a/modules/client/pushrules.cc
+++ b/modules/client/pushrules.cc
@@ -226,7 +226,8 @@ ircd::m::push::method_put
 {
 	resource, "PUT", handle_put,
 	{
-		method_put.REQUIRES_AUTH
+		method_put.REQUIRES_AUTH |
+		method_put.RATE_LIMITED // review this!
 	}
 };
 

--- a/modules/client/register.cc
+++ b/modules/client/register.cc
@@ -43,7 +43,10 @@ register_resource
 m::resource::method
 method_post
 {
-	register_resource, "POST", post__register
+	register_resource, "POST", post__register,
+	{
+		method_post.RATE_LIMITED
+	}
 };
 
 ircd::conf::item<bool>

--- a/modules/client/register_available.cc
+++ b/modules/client/register_available.cc
@@ -31,7 +31,10 @@ register_available_resource
 resource::method
 method_get
 {
-	register_available_resource, "GET", get__register_available
+	register_available_resource, "GET", get__register_available,
+	{
+		method_get.RATE_LIMITED
+	}
 };
 
 mods::import<void (const m::id::user &)>

--- a/modules/client/room_keys/keys.cc
+++ b/modules/client/room_keys/keys.cc
@@ -48,7 +48,8 @@ ircd::m::room_keys_keys_delete
 {
 	room_keys_keys, "DELETE", delete_room_keys_keys,
 	{
-		room_keys_keys_delete.REQUIRES_AUTH
+		room_keys_keys_delete.REQUIRES_AUTH |
+		room_keys_keys_delete.RATE_LIMITED
 	}
 };
 
@@ -73,7 +74,8 @@ ircd::m::room_keys_keys_put
 	room_keys_keys, "PUT", put_room_keys_keys,
 	{
 		// Flags
-		room_keys_keys_put.REQUIRES_AUTH,
+		room_keys_keys_put.REQUIRES_AUTH |
+		room_keys_keys_put.RATE_LIMITED,
 
 		// timeout //TODO: XXX designated
 		30s,
@@ -198,7 +200,8 @@ ircd::m::room_keys_keys_get
 {
 	room_keys_keys, "GET", get_room_keys_keys,
 	{
-		room_keys_keys_get.REQUIRES_AUTH
+		room_keys_keys_get.REQUIRES_AUTH |
+		room_keys_keys_get.RATE_LIMITED
 	}
 };
 

--- a/modules/client/room_keys/version.cc
+++ b/modules/client/room_keys/version.cc
@@ -50,7 +50,8 @@ ircd::m::room_keys_version_post
 {
 	room_keys_version, "POST", post_room_keys_version,
 	{
-		room_keys_version_post.REQUIRES_AUTH
+		room_keys_version_post.REQUIRES_AUTH |
+		room_keys_version_post.RATE_LIMITED
 	}
 };
 
@@ -119,7 +120,8 @@ ircd::m::room_keys_version_delete
 {
 	room_keys_version, "DELETE", delete_room_keys_version,
 	{
-		room_keys_version_delete.REQUIRES_AUTH
+		room_keys_version_delete.REQUIRES_AUTH |
+		room_keys_version_delete.RATE_LIMITED
 	}
 };
 
@@ -175,7 +177,8 @@ ircd::m::room_keys_version_put
 {
 	room_keys_version, "PUT", put_room_keys_version,
 	{
-		room_keys_version_put.REQUIRES_AUTH
+		room_keys_version_put.REQUIRES_AUTH |
+		room_keys_version_put.RATE_LIMITED
 	}
 };
 
@@ -199,7 +202,8 @@ ircd::m::room_keys_version_get
 {
 	room_keys_version, "GET", get_room_keys_version,
 	{
-		room_keys_version_get.REQUIRES_AUTH
+		room_keys_version_get.REQUIRES_AUTH |
+		room_keys_version_get.RATE_LIMITED
 	}
 };
 

--- a/modules/client/rooms/rooms.cc
+++ b/modules/client/rooms/rooms.cc
@@ -146,7 +146,8 @@ method_put
 {
 	rooms_resource, "PUT", put_rooms,
 	{
-		method_put.REQUIRES_AUTH
+		method_put.REQUIRES_AUTH |
+		method_put.RATE_LIMITED
 	}
 };
 
@@ -217,6 +218,7 @@ method_post
 {
 	rooms_resource, "POST", post_rooms,
 	{
-		method_post.REQUIRES_AUTH
+		method_post.REQUIRES_AUTH |
+		method_post.RATE_LIMITED
 	}
 };

--- a/modules/client/search.cc
+++ b/modules/client/search.cc
@@ -55,8 +55,9 @@ ircd::m::search::search_post
 {
 	search_resource, "POST", search_post_handle,
 	{
-		search_post.REQUIRES_AUTH,
-
+		search_post.REQUIRES_AUTH |
+		search_post.RATE_LIMITED,
+ 
 		// Some queries can take a really long time, especially under
 		// development. We don't need the default request timer getting
 		// in the way for now.


### PR DESCRIPTION
Closes #23 (for the most part, refer to the exceptions section below). <ins>Since the actual logic for rate-limiting is not in place (yet), this simply builds but doesn't actually do anything right now</ins>.

### Exceptions

- The following endpoints belong to `groups` in Matrix, which are [not documented very well](https://github.com/matrix-org/matrix-doc/issues/971); based on a discussion on the Matrix spec room, it seems that Matrix will get rid of group endpoints in the future anyways so it's best to ignore these endpoints and their handlers for now.
  - `POST _matrix/client/r0/create_group`
  - `GET /_matrix/client/r0/joined_groups`
  - `GET /_matrix/client/r0/publicised_groups` & `POST /_matrix/client/r0/publicised_groups`
  - Any miscellaneous group-related endpoint not mentioned here.

- The following family of endpoints are related to rooms and are defined in `modules/client/rooms/rooms.h`. These endpoints share common GET/PUT/POST handlers. For the purpose of satisfying the general motivation behind rate-limiting (prevent spam/DDoS attacks against the server), it is acceptable to ignore rate-limiting for GETs for rooms, and impose a fairly relaxed rate for PUTs & POSTs.
  - `GET /_matrix/client/r0/rooms/{roomId}/aliases`
  - `POST /_matrix/client/r0/rooms/{roomId}/invite`
  - `POST /_matrix/client/r0/rooms/{roomId}/join`
  - `POST /_matrix/client/r0/rooms/{roomId}/leave`
  - `POST /_matrix/client/r0/rooms/{roomId}/forget`

- Handlers for `PUT /_matrix/client/r0/pushrules/*` have been ignored. This is because the specs for rate-limiting vary based on the parameters (path/JSON) passed in. This also complicates the design decision for rate-limiting, since it warrants thought whether to rate-limit such endpoints at the abstract HTTP level, or at the application-logic level.
- Handlers for Endpoints related to 3pid are ignored since they aren't really implemented right now. This includes the `/_synapse/admin/v1/deactivate/` endpoint defined in the Admin API since it is related to 3pid.
- The following endpoint: `GET /_matrix/federation/unstable/rooms/` is said to be undocumented in the [comments](https://github.com/matrix-construct/construct/blob/e472a4a5df1dbd67fdf9b3e9fc459b7033cb0721/modules/federation/rooms.cc#L33), and as such has been ignored.